### PR TITLE
Feat/#22 사용자 수익률 API 호출

### DIFF
--- a/src/components/Home/UserInfo.jsx
+++ b/src/components/Home/UserInfo.jsx
@@ -8,7 +8,7 @@ export default function UserInfo() {
 
   useEffect(() => {
     // API 호출
-    axios.get('http://localhost:8080/api/userinfo/2')
+    axios.get('http://localhost:8080/api/userinfo/1')
       .then(response => {
         setUserData(response.data); // API 응답 데이터를 상태에 저장
         setLoading(false);

--- a/src/components/Ranking/RankingDetail.jsx
+++ b/src/components/Ranking/RankingDetail.jsx
@@ -1,0 +1,24 @@
+import RankingUserInfo from '~/components/Ranking/RankingUserInfo';
+import List from '~/components/Home/List';
+
+
+export default function RankingDetail() {
+  // ETF 데이터 (하드코딩)
+  const etfItems = [
+    { name: "우량주가 좋아", rate: 35, isPositive: true },
+    { name: "스타트업", rate: 20, isPositive: true },
+    { name: "개미개미", rate: -4, isPositive: false },
+    { name: "개미개미", rate: -4, isPositive: false },
+    { name: "개미개미", rate: -4, isPositive: false },
+  ];
+
+  return (
+    <div style={{ minWidth: "375px", maxWidth: "430px", margin: "0 auto" }}>
+      {/* 유저 정보 컴포넌트 */}
+      <RankingUserInfo />
+      {/* ETF 목록 */}
+      <h3 style={{ margin: "20px", color: "#333" }}>준기님의 ETF 목록</h3>
+      <List items={etfItems} />
+    </div>
+  );
+}

--- a/src/components/Ranking/RankingUserInfo.jsx
+++ b/src/components/Ranking/RankingUserInfo.jsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+
+export default function RankingUserInfo() {
+  const [userData, setUserData] = useState(null); 
+  const [profitRate, setProfitRate] = useState(null); 
+  const [loading, setLoading] = useState(true); 
+  const [error, setError] = useState(null); 
+
+  useEffect(() => {
+    axios
+      .get('http://localhost:8080/api/userinfo/1')
+      .then((response) => {
+        setUserData(response.data);
+      })
+      .catch((err) => {
+        console.error(err);
+        setError('사용자 정보를 불러올 수 없습니다.');
+      });
+  }, []);
+
+  //수익률
+  useEffect(() => {
+    axios
+      .get('http://localhost:8080/api/userinfo/1/revenue-percentage')
+      .then((response) => {
+        setProfitRate(response.data); 
+        setLoading(false);
+      })
+      .catch((err) => {
+        console.error(err);
+        setError('수익률 정보를 불러올 수 없습니다.');
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) {
+    return <div>로딩 중...</div>; 
+  }
+
+  if (error) {
+    return <div>{error}</div>; 
+  }
+
+  return (
+    <div className="px-3 py-4" style={{ minWidth: '375px', maxWidth: '430px', margin: '0 auto' }}>
+      <div
+        className="d-flex justify-content-between align-items-center"
+        style={{ margin: '0 24px' }}
+      >
+        <div className="d-flex flex-column gap-2">
+          <span className="fw-bold" style={{ fontSize: '26px' }}>
+            {userData.nickname}
+          </span>
+          <div className="d-flex gap-3">
+            <span
+              style={{
+                color: '#666',
+                fontSize: '14px',
+              }}
+            >
+              구독자 {userData.subscriberCount}
+            </span>
+            <span
+              style={{
+                color: profitRate > 0 ? '#ff3b3b' : '#0051c7',
+                fontSize: '14px',
+              }}
+            >
+              수익률 {profitRate > 0 ? '+' : ''}
+              {profitRate}%
+            </span>
+          </div>
+        </div>
+
+        <img
+          src="/images/ink.png"
+          alt="Profile"
+          className="rounded-circle"
+          style={{ width: '60px', height: '60px', objectFit: 'cover' }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/routers/main-router.jsx
+++ b/src/routers/main-router.jsx
@@ -7,6 +7,7 @@ const Init = lazy(() => import('~/routes/init/page'));
 const User = lazy(() => import('~/routes/user/page'));
 const Membership = lazy(() => import('~/routes/membership/page'));
 const Ranking = lazy(() => import('~/routes/ranking/page'));
+const RankingDetail = lazy(() => import('~/routes/rankingDetail/page'));
 const MyPocket = lazy(() => import('~/routes/myPocket/page'));
 const SelectStock = lazy(() => import('~/routes/user/SelectStock'));
 const ETFPocket = lazy(() => import('~/routes/user/ETFPocket'));
@@ -42,6 +43,7 @@ export const mainRoutes = [
           { element: <User />, path: 'user' },
           { element: <Membership />, path: 'membership' },
           { element: <Ranking />, path: 'ranking' },
+          { element: <RankingDetail />, path: 'ranking-detail' }, 
           { element: <MyPocket />, path: 'mypocket' },
           { element: <SelectStock />, path: 'select-stock' },
           { element: <ETFPocket />, path: 'etf-pocket' },

--- a/src/routes/rankingDetail/page.jsx
+++ b/src/routes/rankingDetail/page.jsx
@@ -1,0 +1,7 @@
+import RankingDetail from '~/components/Ranking/RankingDetail';
+
+const RankingDetailRoute = () => {
+  return <RankingDetail />;
+};
+
+export default RankingDetailRoute;


### PR DESCRIPTION
### 변경 내용
- RankingUserInfo.jsx에서 수익률 정보를 표시하기 위해 추가 API 호출 로직 구현:
- GET /api/userinfo/{user_id}/revenue-percentage 엔드포인트를 호출하여 사용자 수익률 데이터를 가져옵니다.
- 수익률 데이터를 profitRate 상태로 관리하여 UI에 반영합니다.